### PR TITLE
Allow requesting news by term name

### DIFF
--- a/alexa-news.php
+++ b/alexa-news.php
@@ -32,7 +32,47 @@ class Alexa_News {
 
 		switch ( $intent ) {
 			case 'Latest':
-				$result = $this->endpoint_content();
+				$term_slot = strtolower( sanitize_text_field( $request->getSlot( 'TermName' ) ) );
+
+				$args = [
+					'post_type'      => alexawp_news_post_types(),
+					'posts_per_page' => max( 1, min( 100, count( $this->placement ) ) ),
+					'tax_query'      => [],
+				];
+
+				if ( $term_slot ) {
+					$news_taxonomies = alexawp_news_taxonomies();
+
+					if ( $news_taxonomies ) {
+						/*
+						 * TODO:
+						 *
+						 * Support for 'name__like'?
+						 * Support for an 'alias' meta field?
+						 * Support for excluding terms?
+						 */
+						$terms = get_terms( [
+							'name' => $term_slot,
+							'taxonomy' => $news_taxonomies,
+						] );
+
+						if ( $terms ) {
+							// 'term_taxonomy_id' query allows omitting 'taxonomy'.
+							$args['tax_query'][] = [
+								'terms' => wp_list_pluck( $terms, 'term_taxonomy_id' ),
+								'field' => 'term_taxonomy_id',
+							];
+						}
+					}
+				}
+
+				if ( $term_slot && ! $args['tax_query'] ) {
+					$response->respond( __( "Sorry! I couldn't find any news about that topic.", 'ahot' ) )->endSession();
+					break;
+				}
+
+				$result = $this->endpoint_content( $args );
+
 				$response
 					->respond( $result['content'] )
 					/* translators: %s: site title */
@@ -67,17 +107,17 @@ class Alexa_News {
 		];
 	}
 
-	private function endpoint_content() {
-		$args = [
-			'post_type' => apply_filters( 'alexawp_post_types', [ 'post' ] ),
-			'posts_per_page' => 5,
+	private function endpoint_content( $args = [] ) {
+		$news_posts = get_posts( array_merge( $args, [
+			'no_found_rows' => true,
 			'post_status' => 'publish',
-		];
-		$news_posts = get_posts( $args );
+		] ) );
+
 		$content = '';
 		$ids = [];
 		if ( ! empty( $news_posts ) && ! is_wp_error( $news_posts ) ) {
 			foreach ( $news_posts as $key => $news_post ) {
+				// Sounds a little strange when there's only one result.
 				$content .= $this->placement[ $key ] . ', ' . $news_post->post_title . '. ';
 				$ids[] = $news_post->ID;
 			}

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -107,7 +107,7 @@ class Alexa_News {
 		];
 	}
 
-	private function endpoint_content( $args = [] ) {
+	private function endpoint_content( $args ) {
 		$news_posts = get_posts( array_merge( $args, [
 			'no_found_rows' => true,
 			'post_status' => 'publish',

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -67,7 +67,7 @@ class Alexa_News {
 				}
 
 				if ( $term_slot && ! $args['tax_query'] ) {
-					$response->respond( __( "Sorry! I couldn't find any news about that topic.", 'ahot' ) )->endSession();
+					$response->respond( __( "Sorry! I couldn't find any news about that topic.", 'alexawp' ) )->endSession();
 					break;
 				}
 

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -117,7 +117,7 @@ class Alexa_News {
 		$ids = [];
 		if ( ! empty( $news_posts ) && ! is_wp_error( $news_posts ) ) {
 			foreach ( $news_posts as $key => $news_post ) {
-				// Sounds a little strange when there's only one result.
+				// TODO: Sounds a little strange when there's only one result.
 				$content .= $this->placement[ $key ] . ', ' . $news_post->post_title . '. ';
 				$ids[] = $news_post->ID;
 			}

--- a/alexawp.php
+++ b/alexawp.php
@@ -59,6 +59,34 @@ function alexawp_autoload_function( $classname ) {
 	}
 }
 
+/**
+ * Get the post types whose content is included in the bundled News skill.
+ *
+ * @return array Post type names.
+ */
+function alexawp_news_post_types() {
+	/**
+	 * Filters the post types whose content is included in the bundled News skill.
+	 *
+	 * @param array $post_types Post type names.
+	 */
+	return apply_filters( 'alexawp_post_types', [ 'post' ] );
+}
+
+/**
+ * Get the taxonomies whose terms can be specified by users invoking the News skill.
+ *
+ * @return array Taxonomy names.
+ */
+function alexawp_news_taxonomies() {
+	$option = get_option( 'alexawp-settings' );
+
+	$taxonomies = ( empty( $option['latest_taxonomies'] ) ) ? [] : $option['latest_taxonomies'];
+
+	// Nonexistant taxonomies can shortcircuit get_terms().
+	return array_filter( $taxonomies, 'taxonomy_exists' );
+}
+
 spl_autoload_register( 'alexawp_autoload_function' );
 
 add_action( 'init', [ 'Alexawp', 'get_instance' ], 0 );

--- a/fields.php
+++ b/fields.php
@@ -94,7 +94,7 @@ function alexawp_fm_alexa_settings() {
 			],
 		] ),
 		'latest_taxonomies' => new \Fieldmanager_Checkboxes( [
-			'label' => __( 'Allow people to ask for content from specific:', 'AlexaWP' ),
+			'label' => __( 'Allow people to ask for content from specific:', 'alexawp' ),
 			'options' => wp_list_pluck( $eligible_news_taxonomy_objects, 'label', 'name' ),
 		] ),
 	];

--- a/fields.php
+++ b/fields.php
@@ -89,27 +89,48 @@ function alexawp_fm_alexa_settings() {
 	$saved_invocation = ( ! empty( $alexawp_settings['news_invocation'] ) );
 
 	if ( $saved_invocation ) {
-		$utterances = "Latest Ask %s for the latest content\r";
-		$utterances .= "Latest Ask %s for the latest articles\r";
-		$utterances .= "Latest Ask %s for the latest stories\r";
-		$utterances .= "Latest Ask %s for the latest news\r";
-		$utterances .= "Latest Get the latest news from %s\r";
-		$utterances .= "Latest Get the latest stories from %s\r";
-		$utterances .= "Latest Get the latest content from %s\r";
-		$utterances .= "Latest Ask %s whats up\r";
-		$utterances .= "Latest Ask %s whats new\r";
-		$utterances .= "ReadPost Read the {PostNumber}\r";
-		$utterances .= "ReadPost Read the {PostNumber} post\r";
-		$utterances .= "ReadPost Read the {PostNumber} article\r";
-		$utterances .= "ReadPost Read the {PostNumber} story\r";
-		$utterances .= "ReadPost Read {PostNumber}\r";
-		$utterances .= "ReadPost Read the {PostNumberWord} post\r";
-		$utterances .= "ReadPost Read the {PostNumberWord} article\r";
-		$utterances .= "ReadPost Read the {PostNumberWord} story\r";
-		$utterances .= "ReadPost Read {PostNumberWord}";
+		$utterances = [
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s for the latest content', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s for the latest articles', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s for the latest stories', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s for the latest news', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Get the latest news from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Get the latest stories from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Get the latest content from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s what\'s up', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: skill invocation name */
+			'Latest ' . sprintf( __( 'Ask %1$s what\'s new', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+			/* translators: 1: cardinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s', 'alexawp' ), '{PostNumber}' ),
+			/* translators: 1: cardinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumber}' ),
+			/* translators: 1: cardinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumber}' ),
+			/* translators: 1: cardinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumber}' ),
+			/* translators: 1: cardinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumber}' ),
+			/* translators: 1: ordinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumberWord}' ),
+			/* translators: 1: ordinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumberWord}' ),
+			/* translators: 1: ordinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumberWord}' ),
+			/* translators: 1: ordinal number of the post to read */
+			'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumberWord}' ),
+		];
+
 		$children['news_utterances'] = new Fieldmanager_TextArea( [
 			'label' => __( "Here's a starting point for your skill's Sample Utterances. You can add these to your news skill in the Amazon developer portal.", 'alexawp' ),
-			'default_value' => str_replace( '%s', $alexawp_settings['news_invocation'], $utterances ),
+			'default_value' => implode( "\r", $utterances ),
 			'skip_save' => true,
 			'attributes' => array_merge(
 				$readonly,

--- a/fields.php
+++ b/fields.php
@@ -71,6 +71,16 @@ add_action( 'fm_post_alexawp-skill', 'alexawp_fm_skill_fact_quote' );
  */
 function alexawp_fm_alexa_settings() {
 	$readonly = [ 'readonly' => 'readonly' ];
+
+	$news_post_types = alexawp_news_post_types();
+	// All public taxonomies associated with news post types. Could be abstracted into a function.
+	$eligible_news_taxonomy_objects = array_filter(
+		get_taxonomies( [ 'public' => true ], 'objects' ),
+		function ( $taxonomy ) use ( $news_post_types ) {
+			return array_intersect( $news_post_types, $taxonomy->object_type );
+		}
+	);
+
 	$children = [
 		'news_invocation' => new Fieldmanager_TextField( [
 			'label' => __( 'What is the invocation name you will use for this skill?', 'alexawp' ),
@@ -83,54 +93,99 @@ function alexawp_fm_alexa_settings() {
 				'style' => 'width: 95%;',
 			],
 		] ),
+		'latest_taxonomies' => new \Fieldmanager_Checkboxes( [
+			'label' => __( 'Allow people to ask for content from specific:', 'AlexaWP' ),
+			'options' => wp_list_pluck( $eligible_news_taxonomy_objects, 'label', 'name' ),
+		] ),
 	];
 
 	$alexawp_settings = get_option( 'alexawp-settings' );
 	$saved_invocation = ( ! empty( $alexawp_settings['news_invocation'] ) );
 
 	if ( $saved_invocation ) {
-		$utterances = [
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s for the latest content', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s for the latest articles', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s for the latest stories', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s for the latest news', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Get the latest news from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Get the latest stories from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Get the latest content from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s what\'s up', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: skill invocation name */
-			'Latest ' . sprintf( __( 'Ask %1$s what\'s new', 'alexawp' ), $alexawp_settings['news_invocation'] ),
-			/* translators: 1: cardinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s', 'alexawp' ), '{PostNumber}' ),
-			/* translators: 1: cardinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumber}' ),
-			/* translators: 1: cardinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumber}' ),
-			/* translators: 1: cardinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumber}' ),
-			/* translators: 1: cardinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumber}' ),
-			/* translators: 1: ordinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumberWord}' ),
-			/* translators: 1: ordinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumberWord}' ),
-			/* translators: 1: ordinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumberWord}' ),
-			/* translators: 1: ordinal number of the post to read */
-			'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumberWord}' ),
-		];
-
 		$children['news_utterances'] = new Fieldmanager_TextArea( [
 			'label' => __( "Here's a starting point for your skill's Sample Utterances. You can add these to your news skill in the Amazon developer portal.", 'alexawp' ),
-			'default_value' => implode( "\r", $utterances ),
+			'default_value' => implode(
+				"\r",
+				[
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest content', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest articles', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest stories', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest news', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Get the latest news from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Get the latest stories from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Get the latest content from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s what\'s up', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name */
+					'Latest ' . sprintf( __( 'Ask %1$s what\'s new', 'alexawp' ), $alexawp_settings['news_invocation'] ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest %2$s articles', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest %2$s content', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest %2$s news', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for the latest %2$s stories', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for %2$s articles', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for %2$s content', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for %2$s news', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s for %2$s stories', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s about %2$s articles', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s about %2$s content', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s about %2$s news', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Ask %1$s about %2$s stories', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get the latest %2$s articles from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get the latest %2$s content from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get the latest %2$s news from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get the latest %2$s stories from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get %2$s articles from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get %2$s content from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get %2$s news from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: skill invocation name, 2: search term */
+					'Latest ' . sprintf( __( 'Get %2$s stories from %1$s', 'alexawp' ), $alexawp_settings['news_invocation'], '{TermName}' ),
+					/* translators: 1: cardinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s', 'alexawp' ), '{PostNumber}' ),
+					/* translators: 1: cardinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumber}' ),
+					/* translators: 1: cardinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumber}' ),
+					/* translators: 1: cardinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumber}' ),
+					/* translators: 1: cardinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumber}' ),
+					/* translators: 1: ordinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s post', 'alexawp' ), '{PostNumberWord}' ),
+					/* translators: 1: ordinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s article', 'alexawp' ), '{PostNumberWord}' ),
+					/* translators: 1: ordinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read the %1$s story', 'alexawp' ), '{PostNumberWord}' ),
+					/* translators: 1: ordinal number of the post to read */
+					'ReadPost ' . sprintf( __( 'Read %1$s', 'alexawp' ), '{PostNumberWord}' ),
+				]
+			),
 			'skip_save' => true,
 			'attributes' => array_merge(
 				$readonly,
@@ -146,17 +201,23 @@ function alexawp_fm_alexa_settings() {
 				'intents' => [
 					[
 						'intent' => 'Latest',
+						'slots' => [
+							[
+								'name' => 'TermName',
+								'type' => 'ALEXAWP_TERM_NAME',
+							],
+						],
 					],
 					[
 						'intent' => 'ReadPost',
-						'slots'  => [
+						'slots' => [
 							[
 								'name' => 'PostNumber',
 								'type' => 'AMAZON.NUMBER',
 							],
 							[
 								'name' => 'PostNumberWord',
-								'type' => 'ALEXAWP.POST_NUMBER_WORD',
+								'type' => 'ALEXAWP_POST_NUMBER_WORD',
 							],
 						],
 					],
@@ -177,15 +238,40 @@ function alexawp_fm_alexa_settings() {
 			new \Fieldmanager_Group( [
 				'description' => __( 'These slot types must be added to your news skill in the Amazon developer portal.', 'alexawp' ),
 				'children' => [
-					'type' => new \Fieldmanager_TextField( 'Type', [
-						'default_value' => 'ALEXAWP.POST_NUMBER_WORD',
+					new \Fieldmanager_TextField( __( 'Type', 'alexawp' ), [
+						'default_value' => 'ALEXAWP_POST_NUMBER_WORD',
 						'attributes' => array_merge(
 							$readonly,
 							[ 'style' => 'width: 50%; font-family: monospace' ]
 						),
 					] ),
-					'values' => new \Fieldmanager_TextArea( 'Values', [
+					new \Fieldmanager_TextArea( __( 'Values', 'alexawp' ), [
 						'default_value' => "first\nsecond\nthird\nfourth\nfifth",
+						'attributes' => array_merge(
+							$readonly,
+							[ 'style' => 'width: 50%; height: 150px; font-family: monospace;' ]
+						),
+					] ),
+					new \Fieldmanager_TextField( __( 'Type', 'alexawp' ), [
+						'default_value' => 'ALEXAWP_TERM_NAME',
+						'attributes' => array_merge(
+							$readonly,
+							[ 'style' => 'width: 50%; font-family: monospace' ]
+						),
+					] ),
+					new \Fieldmanager_TextArea( __( 'Values', 'alexawp' ), [
+						'default_value' => implode(
+							"\n",
+							// Generate sample terms from all available taxonomies.
+							// We want someone to add this slot even if they haven't
+							// turned on taxonomies so it's already there if they do.
+							array_values( array_unique( array_map( 'strtolower', wp_list_pluck( get_terms( [
+								'number' => 100,
+								'order' => 'DESC',
+								'orderby' => 'count',
+								'taxonomy' => array_values( wp_list_pluck( $eligible_news_taxonomy_objects, 'name' ) ),
+							] ), 'name' ) ) ) )
+						),
 						'attributes' => array_merge(
 							$readonly,
 							[ 'style' => 'width: 50%; height: 150px; font-family: monospace;' ]


### PR DESCRIPTION
- Adds checkboxes to the settings page for selecting the taxonomies in which users can request content by term. 
- No taxonomies are enabled by default; the eligible taxonomies are public taxonomies associated with news post types.
- When we detect that a user included a term with their request, look for matching terms and add a `tax_query` to the query for posts. If the user includes a term but no terms were found, bail.
- Adds the `ALEXAWP_TERM_NAME` slot, whose sample values are the 100 most-used terms from the eligible taxonomies.

Also:

- Localizes some strings.
- Renames the `ALEXAWP.POST_NUMBER_WORD` slot because periods are disallowed.

See #9.