### PR TITLE
19 cleanup

### DIFF
--- a/alexa-news.php
+++ b/alexa-news.php
@@ -97,6 +97,10 @@ class Alexa_News {
 					# code...
 					break;
 			}
+		} elseif ( $request instanceof Alexa\Request\LaunchRequest ) {
+			$response->respond( __( 'Ask me whats up!', 'alexawp' ) );
+		} elseif ( $request instanceof Alexa\Request\SessionEndedRequest ) {
+			$response->respond( __( 'Thanks for listening!', 'alexawp' ) )->endSession();
 		}
 	}
 

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -98,7 +98,7 @@ class Alexa_News {
 					break;
 			}
 		} elseif ( $request instanceof Alexa\Request\LaunchRequest ) {
-			$response->respond( __( 'Ask me whats up!', 'alexawp' ) );
+			$response->respond( __( "Ask me what's new!", 'alexawp' ) );
 		}
 	}
 

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -28,33 +28,35 @@ class Alexa_News {
 
 		$request = $event->get_request();
 		$response = $event->get_response();
-		$intent = $request->intentName;
 
-		switch ( $intent ) {
-			case 'Latest':
-				$result = $this->endpoint_content();
-				$response
-					->respond( $result['content'] )
-					/* translators: %s: site title */
-					->withCard( sprintf( __( 'Latest on %s', 'alexawp' ), get_bloginfo( 'name' ) ) )
-					->addSessionAttribute( 'post_ids', $result['ids'] );
-				break;
-			case 'ReadPost':
-				if ( $post_number = $request->getSlot( 'PostNumberWord' ) ) {
-					$post_number = $this->numbers[ $post_number ] -1;
-				} elseif ( $post_number = $request->getSlot( 'PostNumber' ) ) {
-					$post_number = $post_number - 1;
-				}
-				$post_ids = $request->session->attributes['post_ids'];
-				$result = $this->endpoint_single_post( $post_ids[ $post_number ] );
-				$response->respond( $result['content'] )->withCard( $result['title'] )->endSession();
-				break;
-			case 'AMAZON.StopIntent':
-				$response->respond( __( 'Thanks for listening!', 'alexawp' ) )->endSession();
-				break;
-			default:
-				# code...
-				break;
+		if ( $request instanceof Alexa\Request\IntentRequest ) {
+			$intent = $request->intentName;
+			switch ( $intent ) {
+				case 'Latest':
+					$result = $this->endpoint_content();
+					$response
+						->respond( $result['content'] )
+						/* translators: %s: site title */
+						->withCard( sprintf( __( 'Latest on %s', 'alexawp' ), get_bloginfo( 'name' ) ) )
+						->addSessionAttribute( 'post_ids', $result['ids'] );
+					break;
+				case 'ReadPost':
+					if ( $post_number = $request->getSlot( 'PostNumberWord' ) ) {
+						$post_number = $this->numbers[ $post_number ] -1;
+					} elseif ( $post_number = $request->getSlot( 'PostNumber' ) ) {
+						$post_number = $post_number - 1;
+					}
+					$post_ids = $request->session->attributes['post_ids'];
+					$result = $this->endpoint_single_post( $post_ids[ $post_number ] );
+					$response->respond( $result['content'] )->withCard( $result['title'] )->endSession();
+					break;
+				case 'AMAZON.StopIntent':
+					$response->respond( __( 'Thanks for listening!', 'alexawp' ) )->endSession();
+					break;
+				default:
+					# code...
+					break;
+			}
 		}
 	}
 

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -99,8 +99,6 @@ class Alexa_News {
 			}
 		} elseif ( $request instanceof Alexa\Request\LaunchRequest ) {
 			$response->respond( __( 'Ask me whats up!', 'alexawp' ) );
-		} elseif ( $request instanceof Alexa\Request\SessionEndedRequest ) {
-			$response->respond( __( 'Thanks for listening!', 'alexawp' ) )->endSession();
 		}
 	}
 

--- a/alexa-news.php
+++ b/alexa-news.php
@@ -3,7 +3,7 @@
 use Alexa\Request\IntentRequest;
 
 class Alexa_News {
-	public $numbers = [
+	public $numbers = array(
 		'First' => 1,
 		'1st' => 1,
 		'Second' => 2,
@@ -14,15 +14,15 @@ class Alexa_News {
 		'4th' => 4,
 		'Fifth' => 5,
 		'5th' => 5,
-	];
+	);
 
-	public $placement = [
+	public $placement = array(
 		'First',
 		'Second',
 		'Third',
 		'Fourth',
 		'Fifth',
-	];
+	);
 
 	public function news_request( $event ) {
 
@@ -61,21 +61,21 @@ class Alexa_News {
 	private function endpoint_single_post( $id ) {
 		$single_post = get_post( $id );
 		$post_content = strip_tags( strip_shortcodes( $single_post->post_content ) );
-		return [
+		return array(
 			'content' => $post_content,
 			'title' => $single_post->post_title,
-		];
+		);
 	}
 
 	private function endpoint_content() {
-		$args = [
+		$args = array(
 			'post_type' => apply_filters( 'alexawp_post_types', [ 'post' ] ),
 			'posts_per_page' => 5,
 			'post_status' => 'publish',
-		];
+		);
 		$news_posts = get_posts( $args );
 		$content = '';
-		$ids = [];
+		$ids = array();
 		if ( ! empty( $news_posts ) && ! is_wp_error( $news_posts ) ) {
 			foreach ( $news_posts as $key => $news_post ) {
 				$content .= $this->placement[ $key ] . ', ' . $news_post->post_title . '. ';
@@ -83,9 +83,9 @@ class Alexa_News {
 			}
 		}
 
-		return [
+		return array(
 			'content' => $content,
 			'ids' => $ids,
-		];
+		);
 	}
 }

--- a/alexa/request/certificate.php
+++ b/alexa/request/certificate.php
@@ -41,6 +41,10 @@ class Certificate {
 	}
 
 	public function validate_request( $request_data ) {
+
+		// setting the required http status code 400 for certificate error (we will set back to 200 after all certification checks are concluded with success)
+		http_response_code( 400 );
+
 		$request_parsed = json_decode( $request_data, true );
 		// Validate the entire request by:
 
@@ -55,6 +59,9 @@ class Certificate {
 
 		// 4. Verifying the request signature
 		$this->validaterequest_signature( $request_data );
+
+		// setting the http status code back to 200 since we didn't have any certification error
+		http_response_code( 200 );
 	}
 
 	/**

--- a/alexa/request/certificate.php
+++ b/alexa/request/certificate.php
@@ -43,7 +43,7 @@ class Certificate {
 	public function validate_request( $request_data ) {
 
 		// Set required http status code 400 for certificate error
-		http_response_code( 400 );
+		status_header( 400 );
 
 		$request_parsed = json_decode( $request_data, true );
 		// Validate the entire request by:
@@ -61,7 +61,7 @@ class Certificate {
 		$this->validaterequest_signature( $request_data );
 
 		// Set http status code back to 200
-		http_response_code( 200 );
+		status_header( 200 );
 	}
 
 	/**

--- a/alexa/request/certificate.php
+++ b/alexa/request/certificate.php
@@ -42,7 +42,7 @@ class Certificate {
 
 	public function validate_request( $request_data ) {
 
-		// setting the required http status code 400 for certificate error (we will set back to 200 after all certification checks are concluded with success)
+		// Set required http status code 400 for certificate error
 		http_response_code( 400 );
 
 		$request_parsed = json_decode( $request_data, true );
@@ -60,7 +60,7 @@ class Certificate {
 		// 4. Verifying the request signature
 		$this->validaterequest_signature( $request_data );
 
-		// setting the http status code back to 200 since we didn't have any certification error
+		// Set http status code back to 200
 		http_response_code( 200 );
 	}
 

--- a/alexa/request/sessionendedrequest.php
+++ b/alexa/request/sessionendedrequest.php
@@ -8,6 +8,6 @@ class SessionEndedRequest extends Request {
 	public function __construct( $raw_data ) {
 		parent::__construct( $raw_data );
 
-		$this->reason = $data['request']['reason'];
+		$this->reason = $this->data['request']['reason'];
 	}
 }

--- a/alexawp.php
+++ b/alexawp.php
@@ -61,7 +61,7 @@ function alexawp_autoload_function( $classname ) {
 
 spl_autoload_register( 'alexawp_autoload_function' );
 
-add_action( 'init', [ 'Alexawp', 'get_instance' ], 0 );
+add_action( 'init', array( 'Alexawp', 'get_instance' ), 0 );
 
 use Alexa\Request\IntentRequest;
 use Alexa\Request\LaunchRequest;
@@ -79,8 +79,8 @@ class Alexawp {
 	}
 
 	protected function __construct() {
-		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-		add_action( 'after_setup_theme', [ $this, 'add_image_size' ] );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_action( 'after_setup_theme', array( $this, 'add_image_size' ) );
 	}
 
 	/**
@@ -88,20 +88,20 @@ class Alexawp {
 	 */
 	public function register_routes() {
 		// Endpoint for flash briefing
-		register_rest_route( 'alexawp/v1', '/skill/briefing', [
-			'callback' => [ $this, 'briefing_request' ],
-			'methods' => [ 'GET' ],
-		] );
+		register_rest_route( 'alexawp/v1', '/skill/briefing', array(
+			'callback' => array( $this, 'briefing_request' ),
+			'methods' => array( 'GET' ),
+		) );
 		// Endpoint for News skill
-		register_rest_route( 'alexawp/v1', '/skill/news', [
-			'callback' => [ $this, 'alexawp_news_request' ],
-			'methods' => [ 'POST' ],
-		] );
+		register_rest_route( 'alexawp/v1', '/skill/news', array(
+			'callback' => array( $this, 'alexawp_news_request' ),
+			'methods' => array( 'POST' ),
+		) );
 		// Endpoint for all other skills
-		register_rest_route( 'alexawp/v1', '/skill/(?P<id>\d+)', [
-			'callback' => [ $this, 'alexawp_skill_request' ],
-			'methods' => [ 'POST' ],
-		] );
+		register_rest_route( 'alexawp/v1', '/skill/(?P<id>\d+)', array(
+			'callback' => array( $this, 'alexawp_skill_request' ),
+			'methods' => array( 'POST' ),
+		) );
 	}
 
 	/**
@@ -131,6 +131,7 @@ class Alexawp {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function alexawp_skill_request( WP_REST_Request $request ) {
+		error_log( 'hi');
 		$body = $this->access_protected( $request, 'body' );
 
 		$id = absint( $request->get_param( 'id' ) );
@@ -214,17 +215,17 @@ class Alexawp {
 
 	private function fail_response( $e ) {
 		return new WP_REST_Response(
-			[
+			array(
 				'version' => '1.0',
-				'response' => [
-					'outputSpeech' => [
+				'response' => array(
+					'outputSpeech' => array(
 						'type' => 'PlainText',
 						'text' => $e->getMessage(),
-					],
+					),
 					'shouldEndSession' => true,
-				],
-				'sessionAttributes' => [],
-			],
+				),
+				'sessionAttributes' => array(),
+			),
 			200
 		);
 	}

--- a/alexawp.php
+++ b/alexawp.php
@@ -131,7 +131,6 @@ class Alexawp {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function alexawp_skill_request( WP_REST_Request $request ) {
-		error_log( 'hi');
 		$body = $this->access_protected( $request, 'body' );
 
 		$id = absint( $request->get_param( 'id' ) );
@@ -174,7 +173,7 @@ class Alexawp {
 				$alexa_settings = get_option( 'alexawp-settings' );
 				$app_id = $alexa_settings['news_id'];
 				$certificate = new \Alexa\Request\Certificate( $request->get_header( 'signaturecertchainurl' ), $request->get_header( 'signature' ), $app_id );
-				$alexa = new \Alexa\Request\IntentRequest( $body, $app_id );
+				$alexa = new \Alexa\Request\Request( $body, $app_id );
 				$alexa->setCertificateDependency( $certificate );
 
 				// Parse and validate the request.

--- a/fields.php
+++ b/fields.php
@@ -91,8 +91,8 @@ function alexawp_fm_alexa_settings() {
 		$utterances .= "Latest Get the latest news from %s\r";
 		$utterances .= "Latest Get the latest stories from %s\r";
 		$utterances .= "Latest Get the latest content from %s\r";
-		$utterances .= "Latest Ask %s whats up\r";
-		$utterances .= "Latest Ask %s whats new\r";
+		$utterances .= "Latest Ask %s what's up\r";
+		$utterances .= "Latest Ask %s what's new\r";
 		$utterances .= "ReadPost Read the {PostNumber}\r";
 		$utterances .= "ReadPost Read the {PostNumber} post\r";
 		$utterances .= "ReadPost Read the {PostNumber} article\r";

--- a/fields.php
+++ b/fields.php
@@ -221,6 +221,9 @@ function alexawp_fm_alexa_settings() {
 							],
 						],
 					],
+					[
+						'intent' => 'AMAZON.StopIntent',
+					]
 				],
 			],
 			JSON_PRETTY_PRINT

--- a/fields.php
+++ b/fields.php
@@ -223,7 +223,7 @@ function alexawp_fm_alexa_settings() {
 					],
 					[
 						'intent' => 'AMAZON.StopIntent',
-					]
+					],
 				],
 			],
 			JSON_PRETTY_PRINT


### PR DESCRIPTION
Fixes #19 by using the Request class and then checking the Request type. Only IntentRequest has a name, so we get the name within that check. 

Adds a basic LaunchRequest handler for the News skill. 
Changes some code to use standard array syntax.
Fixes setting the `reason` property in SessionEndedRequest.
Adds StopIntent to intent schema