### PR TITLE
Display notices in the Dashboard when requirements are missing

### DIFF
--- a/alexawp.php
+++ b/alexawp.php
@@ -24,6 +24,11 @@ function alexawp_deactivate() {
 }
 
 /**
+ * Compatibility requirements.
+ */
+require_once( ALEXAWP_PATH . '/compat.php' );
+
+/**
  * Post Type Base Class
  */
 require_once( ALEXAWP_PATH . '/post-types/class-alexawp-post-type.php' );

--- a/compat.php
+++ b/compat.php
@@ -2,8 +2,6 @@
 /**
  * AlexaWP compatibility functionality.
  *
- * Checks for plugin requirements and alerts users to missing requirements.
- *
  * @package AlexaWP
  */
 
@@ -65,6 +63,26 @@ function alexawp_check_requirements() {
  */
 function alexawp_admin_notice( $classes, $message ) {
 	printf( '<div class="%s"><p>%s</p></div>', esc_attr( implode( ' ', $classes ) ), esc_html( $message ) );
+}
+
+/**
+ * Shim wp_generate_uuid4() if this WordPress version doesn't include it.
+ *
+ * @return string UUID.
+ */
+function alexawp_generate_uuid4() {
+	if ( function_exists( 'wp_generate_uuid4' ) ) {
+		return wp_generate_uuid4();
+	}
+
+	// As of WordPress 4.7.2.
+	return sprintf( '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+		mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ),
+		mt_rand( 0, 0xffff ),
+		mt_rand( 0, 0x0fff ) | 0x4000,
+		mt_rand( 0, 0x3fff ) | 0x8000,
+		mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff ), mt_rand( 0, 0xffff )
+	);
 }
 
 /**

--- a/compat.php
+++ b/compat.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * AlexaWP compatibility functionality.
+ *
+ * Checks for plugin requirements and alerts users to missing requirements.
+ *
+ * @package AlexaWP
+ */
+
+/**
+ * Check whether the plugin requirements are met.
+ *
+ * @return \WP_Error WP_Error object with error data for unmet requirements, if any.
+ */
+function alexawp_check_requirements() {
+	global $wp_version;
+
+	$minimum_wp_version    = '4.4';
+	$unsupported_wordpress = version_compare( $wp_version, $minimum_wp_version, '<' );
+	$minimum_fm_version    = '1.0';
+	$fm_defined            = defined( 'FM_VERSION' );
+
+	$check                 = new \WP_Error;
+
+	if ( $unsupported_wordpress ) {
+		$check->add(
+			'unsupported_wordpress',
+			sprintf(
+				/* translators: 1: minimum WordPress version, 2: current WordPress version */
+				__( 'AlexaWP requires at least WordPress version %1$s. You are currently running version %2$s.', 'alexawp' ),
+				$minimum_wp_version,
+				$wp_version
+			)
+		);
+	}
+
+	if ( ! $unsupported_wordpress && ! class_exists( '\WP_REST_Controller' ) ) {
+		$check->add( 'no_rest_api', __( 'AlexaWP requires the WordPress REST API.', 'alexawp' ) );
+	}
+
+	if ( ! $fm_defined ) {
+		$check->add( 'no_fieldmanager', __( 'AlexaWP requires the WordPress Fieldmanager plugin.', 'alexawp' ) );
+	}
+
+	if ( $fm_defined && version_compare( FM_VERSION, $minimum_fm_version, '<' ) ) {
+		$check->add(
+			'unsupported_fieldmanager',
+			sprintf(
+				/* translators: 1: minimum Fieldmanager version, 2: current Fieldmanager version */
+				__( 'AlexaWP requires at least Fieldmanager version %1$s. You are currently running version %2$s.', 'alexawp' ),
+				$minimum_fm_version,
+				FM_VERSION
+			)
+		);
+	}
+
+	return $check;
+}
+
+/**
+ * Print a notice for the Dashboard.
+ *
+ * @param array  $classes Notice HTML classes.
+ * @param string $message Notice text.
+ */
+function alexawp_admin_notice( $classes, $message ) {
+	printf( '<div class="%s"><p>%s</p></div>', esc_attr( implode( ' ', $classes ) ), esc_html( $message ) );
+}
+
+/**
+ * Print an admin "error" notice for each unmet plugin requirement.
+ */
+function alexawp_print_requirements_errors() {
+	foreach ( alexawp_check_requirements()->get_error_messages() as $message ) {
+		alexawp_admin_notice( array( 'notice notice-error' ), $message );
+	}
+}
+add_action( 'after_setup_theme', 'alexawp_print_requirements_errors' );

--- a/compat.php
+++ b/compat.php
@@ -75,4 +75,4 @@ function alexawp_print_requirements_errors() {
 		alexawp_admin_notice( array( 'notice notice-error' ), $message );
 	}
 }
-add_action( 'after_setup_theme', 'alexawp_print_requirements_errors' );
+add_action( 'admin_init', 'alexawp_print_requirements_errors' );

--- a/compat.php
+++ b/compat.php
@@ -32,7 +32,7 @@ function alexawp_check_requirements() {
 		);
 	}
 
-	if ( ! $unsupported_wordpress && ! class_exists( '\WP_REST_Controller' ) ) {
+	if ( ! $unsupported_wordpress && ! class_exists( '\WP_REST_Response' ) ) {
 		$check->add( 'no_rest_api', __( 'AlexaWP requires the WordPress REST API.', 'alexawp' ) );
 	}
 

--- a/fields.php
+++ b/fields.php
@@ -90,7 +90,7 @@ function alexawp_fm_briefing_content() {
 	] );
 
 	if ( ! get_post_meta( $post_id, 'alexawp_briefing_uuid', true ) ) {
-		$uuid->default_value = wp_generate_uuid4();
+		$uuid->default_value = alexawp_generate_uuid4();
 	}
 
 	array_unshift( $children, $display_if, $uuid );


### PR DESCRIPTION
See #6, #7.

For now, this only prints admin notices. @tomharrigan, do you think there are circumstances when the plugin should also deactivate itself or react in some other way?

Also, regarding this point:

> Won't exist for older WP versions, but may exist as a plugin for them. If we leverage any 4.7 endpoints, we may need additional checks there and then register custom endpoints if the site doesn't have them.

As far as I know, we aren't leveraging any 4.7 endpoints yet, and the REST API plugin requires 4.6. So, for most users, 4.4 is the minimum version. But this PR also generates an admin notice for special cases like VIP where WordPress is 4.4 or later but the REST infrastructure is still missing.