### PR TITLE
Make sure read-only fields have names

### DIFF
--- a/fields.php
+++ b/fields.php
@@ -332,9 +332,11 @@ function alexawp_fm_alexa_settings() {
 		'label' => __( 'Custom Slot Types', 'alexawp' ),
 		'children' => [
 			new \Fieldmanager_Group( [
+				'name' => 'custom_slot_type_children',
 				'description' => __( 'These slot types must be added to your news skill in the Amazon developer portal.', 'alexawp' ),
 				'children' => [
 					new \Fieldmanager_TextField( __( 'Type', 'alexawp' ), [
+						'name' => 'ALEXAWP_POST_NUMBER_WORD',
 						'default_value' => 'ALEXAWP_POST_NUMBER_WORD',
 						'attributes' => array_merge(
 							$readonly,
@@ -342,6 +344,7 @@ function alexawp_fm_alexa_settings() {
 						),
 					] ),
 					new \Fieldmanager_TextArea( __( 'Values', 'alexawp' ), [
+						'name' => 'ALEXAWP_POST_NUMBER_WORD_values',
 						'default_value' => "first\nsecond\nthird\nfourth\nfifth",
 						'attributes' => array_merge(
 							$readonly,
@@ -349,6 +352,7 @@ function alexawp_fm_alexa_settings() {
 						),
 					] ),
 					new \Fieldmanager_TextField( __( 'Type', 'alexawp' ), [
+						'name' => 'ALEXAWP_TERM_NAME',
 						'default_value' => 'ALEXAWP_TERM_NAME',
 						'attributes' => array_merge(
 							$readonly,
@@ -356,6 +360,7 @@ function alexawp_fm_alexa_settings() {
 						),
 					] ),
 					new \Fieldmanager_TextArea( __( 'Values', 'alexawp' ), [
+						'name' => 'ALEXAWP_TERM_NAME_values',
 						'default_value' => implode(
 							"\n",
 							// Generate sample terms from all available taxonomies.


### PR DESCRIPTION
A child of a `\Fieldmanager_Group` that is not manually assigned a name
has a name automatically assigned based on its index in the array. Any
loose checks for those field names (like `'my_field' == $this->name`)
can return true for those fields, causing code to run intentionally.