### PR TITLE
Skill endpoint admin

### DIFF
--- a/class-voicewp.php
+++ b/class-voicewp.php
@@ -184,12 +184,13 @@ class Voicewp {
 		$skill_type = get_post_meta( $id, 'voicewp_skill_type', true );
 
 		switch ( $skill_type ) {
+			case 'Quote':
 			case 'fact_quote':
 				$quote = new \Alexa\Skill\Quote;
 				$quote->quote_request( $id, $request, $response );
 				break;
 			default:
-				do_action( 'voicewp_custom_skill', $skill_type, $id );
+				do_action( 'voicewp_custom_skill', $skill_type, $id, $request, $response );
 				break;
 		}
 	}

--- a/fields.php
+++ b/fields.php
@@ -5,6 +5,8 @@
  */
 function voicewp_fm_alexa_app_settings() {
 
+	$post_id = ( isset( $_GET['post'] ) ) ? absint( $_GET['post'] ) : 0;
+
 	$children = array(
 		new \Fieldmanager_Select( __( 'Skill Type', 'voicewp' ), array(
 			'name' => 'type',
@@ -33,6 +35,23 @@ function voicewp_fm_alexa_app_settings() {
 			),
 		) ),
 	);
+
+	// If there's a post ID, output the REST endpoint for use in the amazon developer portal
+	if ( $post_id ) {
+		$children['readonly_skill_url'] = new \Fieldmanager_TextField( array(
+			'label' => __( 'This is the endpoint URL of your skill. Paste this within the configuration tab for your skill in the developer portal.', 'voicewp' ),
+			'default_value' => home_url( '/wp-json/voicewp/v1/skill/' ) . $post_id,
+			'skip_save' => true,
+			'attributes' => array(
+				'readonly' => 'readonly',
+				'style' => 'width: 95%;',
+			),
+			'display_if' => array(
+				'src' => 'is_standalone',
+				'value' => true,
+			),
+		) );
+	}
 
 	$fm = new \Fieldmanager_Group( array(
 		'name' => 'voicewp_skill',

--- a/post-types/class-voicewp-post-type-skill.php
+++ b/post-types/class-voicewp-post-type-skill.php
@@ -46,7 +46,10 @@ class Voicewp_Post_Type_Skill extends Voicewp_Post_Type {
 				'menu_name'          => __( 'Skills', 'voicewp' ),
 			),
 			'menu_icon' => 'dashicons-awards',
-			'public' => true,
+			'public' => false,
+			'publicly_queryable' => true,
+			'show_in_menu' => true,
+			'show_ui' => true,
 			'supports' => array( 'title' ),
 		) );
 	}
@@ -74,6 +77,9 @@ class Voicewp_Post_Type_Skill extends Voicewp_Post_Type {
 		if ( empty( $is_standalone ) && ! empty( $skill_type ) ) {
 			$old_index = $custom_skill_index = get_option( 'voicewp_skill_index_map', array() );
 			$skill = '\Alexa\Skill\\' . $skill_type;
+			if ( ! class_exists( $skill ) ) {
+				return;
+			}
 			$skill = new $skill;
 
 			foreach ( $skill->intents as $intent ) {


### PR DESCRIPTION
update post type params to match briefing post type

Prevents public URLs from being created/displayed, which were confusing to end users. We added a readonly field that displays the REST endpoint URL.

Create readonly field for endpoint URL if post ID exists