### PR TITLE
override briefing source

### DIFF
--- a/alexa/skill/briefing.php
+++ b/alexa/skill/briefing.php
@@ -16,7 +16,14 @@ class Briefing {
 	 * @return array Response for Flash Briefing
 	 */
 	public function briefing_request() {
-		$responses = apply_filters( 'voicewp_override_briefing', array() );
+		/**
+		 * Allows briefing content to be overridden for customization purposes.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param array An array of briefing items.
+		 */
+		$responses = apply_filters( 'voicewp_pre_get_briefing', array() );
 
 		if ( ! empty( $responses ) ) {
 			return $responses;

--- a/alexa/skill/briefing.php
+++ b/alexa/skill/briefing.php
@@ -16,7 +16,11 @@ class Briefing {
 	 * @return array Response for Flash Briefing
 	 */
 	public function briefing_request() {
-		$responses = array();
+		$responses = apply_filters( 'voicewp_override_briefing', array() );
+
+		if ( ! empty( $responses ) ) {
+			return $responses;
+		}
 
 		// This logic could be both abstracted and used with array_map().
 		foreach (


### PR DESCRIPTION
Allows the briefing content to be highjacked so sites can completely customize in out of the box ways and with different types of content