### PR TITLE
Fix &nbsp insertion

### DIFF
--- a/alexa/skill/briefing.php
+++ b/alexa/skill/briefing.php
@@ -43,7 +43,7 @@ class Briefing {
 			$response = array(
 				'uid' => get_post_meta( $post->ID, 'voicewp_briefing_uuid', true ),
 				'updateDate' => get_post_modified_time( 'Y-m-d\TH:i:s.\0\Z', true, $post ),
-				'titleText' => get_the_title( $post ),
+				'titleText' => $post->post_title,
 				'mainText' => '',
 				'redirectionUrl' => home_url(),
 			);


### PR DESCRIPTION
a filter on 'the_title', ‘widont’ prevents typographical orphans by replacing the last whitespace character with a `&nbsp;`

We don’t want that to be output in the title because amazon will display the raw `&nbsp;`, and we already have the post object, so might as well get the title directly from the object instead of calling get_the_title and applying unneeded filters or having to unhook filters for proper output.