### PR TITLE
updates for PHPCS

### DIFF
--- a/alexa/request/request.php
+++ b/alexa/request/request.php
@@ -75,8 +75,9 @@ class Request {
 
 		// Instantiate a new Certificate validator if none is injected
 		// as our dependency.
-		if ( ! isset( $this->certificate ) ) {
-			$this->certificate = new Certificate( $_SERVER['HTTP_SIGNATURECERTCHAINURL'], $_SERVER['HTTP_SIGNATURE'] );
+		if ( ! isset( $this->certificate ) && ( isset( $_SERVER ) && isset( $_SERVER['HTTP_SIGNATURECERTCHAINURL'] ) && isset( $_SERVER['HTTP_SIGNATURE'] ) ) ) {
+			$this->certificate = new Certificate( esc_url_raw( wp_unslash( $_SERVER['HTTP_SIGNATURECERTCHAINURL'] ) ), sanitize_text_field( wp_unslash( $_SERVER['HTTP_SIGNATURE'] ) )
+			);
 		}
 		if ( ! isset( $this->application ) ) {
 			$this->application = new Application( $this->application_id );

--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -63,6 +63,7 @@ class News {
 							break;
 						}
 					}
+					// No break. Logic continues into Latest case
 				case 'Latest':
 					/* Since the above switch statement doesn't break,
 					 * it will continue running into this block,

--- a/inc/class-voicewp-setup.php
+++ b/inc/class-voicewp-setup.php
@@ -150,7 +150,7 @@ class Voicewp_Setup {
 			// tilda character denotes rendering as span rather than div
 			$settings['custom_elements'] .= ',~' . $tag;
 			if ( ! empty( $attributes ) ) {
-				$settings['extended_valid_elements'] .= ',' . $tag . '['. implode( '|', array_keys( $attributes ) ) . ']';
+				$settings['extended_valid_elements'] .= ',' . $tag . '[' . implode( '|', array_keys( $attributes ) ) . ']';
 			}
 		}
 		$settings['extended_valid_elements'] = ltrim( $settings['extended_valid_elements'], ',' );


### PR DESCRIPTION
Fix validation and sanitization errors in PHPCS around `$_SERVER` var in setting certificate.
The other fixed issues were commenting a fall-through in a switch statement, and dealing with a spacing issue on a concat operator. 