### PR TITLE
Cert fix user prompt

### DIFF
--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -86,8 +86,10 @@ class News {
 					$voicewp_settings = get_option( 'voicewp-settings' );
 					$skill_name = ( ! empty( $voicewp_settings['skill_name'] ) ) ? $voicewp_settings['skill_name'] : get_bloginfo( 'name' );
 
+					$prompt = ( ! empty( $voicewp_settings['list_prompt'] ) ) ? $voicewp_settings['list_prompt'] : __( 'Which article would you like to hear?', 'voicewp' );
+
 					$response
-						->respond( $result['content'] )
+						->respond( $result['content'] . $prompt )
 						/* translators: %s: site title */
 						->with_card( sprintf( __( 'Latest from %s', 'voicewp' ), $skill_name ), ( ( ! empty( $result['card_content'] ) ) ? $result['card_content'] : '' ) )
 						->add_session_attribute( 'post_ids', $result['ids'] );

--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -85,7 +85,6 @@ class News {
 
 					$voicewp_settings = get_option( 'voicewp-settings' );
 					$skill_name = ( ! empty( $voicewp_settings['skill_name'] ) ) ? $voicewp_settings['skill_name'] : get_bloginfo( 'name' );
-
 					$prompt = ( ! empty( $voicewp_settings['list_prompt'] ) ) ? $voicewp_settings['list_prompt'] : __( 'Which article would you like to hear?', 'voicewp' );
 
 					$response

--- a/inc/fields.php
+++ b/inc/fields.php
@@ -243,19 +243,25 @@ function voicewp_fm_alexa_settings() {
 			'label' => __( 'Welcome message', 'voicewp' ),
 			'description' => __( 'This is the message a person hears when they open your skill with an utterance such as "Alexa, open {your skill name}"', 'voicewp' ),
 			'default_value' => __( 'Welcome to the {put your skill name here} Skill. This skill allows you to listen to content from {your site name}. You can ask questions like: What are the latest articles? ... Now, what can I help you with.', 'voicewp' ),
-			'attributes' => array( 'style' => 'width: 95%; height: 100px;' ),
+			'attributes' => array( 'style' => 'width: 95%; height: 70px;' ),
 		) ),
 		'help_intent' => new Fieldmanager_TextArea( array(
 			'label' => __( 'Help message', 'voicewp' ),
 			'description' => __( "This is the message a person hears when they ask your skill for 'help'", 'voicewp' ),
 			'default_value' => __( "{put your skill name here} provides you with the latest content from {your site name}. You can ask me for the latest articles, and then select an item from the list by saying, for example, 'read the 3rd article' Or you can also say exit... What can I help you with?", 'voicewp' ),
-			'attributes' => array( 'style' => 'width: 95%; height: 100px;' ),
+			'attributes' => array( 'style' => 'width: 95%; height: 70px;' ),
+		) ),
+		'list_prompt' => new Fieldmanager_TextArea( array(
+			'label' => __( 'List Prompt', 'voicewp' ),
+			'description' => __( 'This message prompts the user to select a piece of content to be read after hearing the headlines.', 'voicewp' ),
+			'default_value' => __( 'Which article would you like to hear?', 'voicewp' ),
+			'attributes' => array( 'style' => 'width: 95%; height: 50px;' ),
 		) ),
 		'stop_intent' => new Fieldmanager_TextArea( array(
 			'label' => __( 'Stop message', 'voicewp' ),
 			'description' => __( 'You can optionally provide a message when a person is done with your skill.', 'voicewp' ),
 			'default_value' => __( 'Thanks for listening!', 'voicewp' ),
-			'attributes' => array( 'style' => 'width: 95%; height: 100px;' ),
+			'attributes' => array( 'style' => 'width: 95%; height: 50px;' ),
 		) ),
 		'news_id' => new Fieldmanager_TextField( array(
 			'label' => __( 'News skill ID', 'voicewp' ),


### PR DESCRIPTION
Fixes issue that causes certification rejection from amazon. After a list of posts are read, the skill needs to prompt the user to select one of those items to be read.