### PR TITLE
fix html entity parse issues

### DIFF
--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -174,7 +174,7 @@ class News {
 	public function format_single_post( $id, $single_post ) {
 		$voicewp_instance = \Voicewp_Setup::get_instance();
 		// Strip shortcodes and markup other than SSML
-		$post_content = preg_replace( '|^(\s*)(https?://[^\s<>"]+)(\s*)$|im', '', wp_kses( strip_shortcodes( $single_post->post_content ), $voicewp_instance::$ssml ) );
+		$post_content = html_entity_decode( preg_replace( '|^(\s*)(https?://[^\s<>"]+)(\s*)$|im', '', wp_kses( strip_shortcodes( $single_post->post_content ), $voicewp_instance::$ssml ) ) );
 		// Apply user defined dictionary to content as ssml
 		$dictionary = get_option( 'voicewp_user_dictionary', array() );
 		if ( ! empty( $dictionary ) ) {


### PR DESCRIPTION
having an `&nbsp;` for example, in the content, would break the reading of the output text and create an error.