### PR TITLE
fix issue with scheduled briefings not updating on Alexa/JSON feed

### DIFF
--- a/inc/post-types/class-voicewp-post-type-briefing.php
+++ b/inc/post-types/class-voicewp-post-type-briefing.php
@@ -54,7 +54,6 @@ class Voicewp_Post_Type_Briefing extends Voicewp_Post_Type {
 		if (
 			empty( $post_id )
 			|| wp_is_post_revision( $post_id )
-			|| ( defined( 'WP_IMPORTING' ) && WP_IMPORTING === true )
 			|| ( $post->post_type !== $this->name )
 			|| 'publish' !== get_post_status( $post_id )
 		) {


### PR DESCRIPTION
On VIP, WP_IMPORTING is true when running the task that publishes future posts, causing the cached data to not be deleted/refreshed. Removing this check resolves the issue.

Example: Briefings for saturday and sunday are scheduled on Friday. When saturday roles around, the post will be published, but the JSON feed will still be stale because the check on save_post exited early because WP_IMPORTING is true. The feed will not refresh until the update/publish button is pressed again, or the cache expires naturally.