### PR TITLE
strip script tags in post content

### DIFF
--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -178,7 +178,14 @@ class News {
 	public function format_single_post( $id, $single_post ) {
 		$voicewp_instance = \Voicewp_Setup::get_instance();
 		// Strip shortcodes and markup other than SSML
-		$post_content = html_entity_decode( preg_replace( '|^(\s*)(https?://[^\s<>"]+)(\s*)$|im', '', wp_kses( strip_shortcodes( $single_post->post_content ), $voicewp_instance::$ssml ) ) );
+		$post_content = html_entity_decode( wp_kses( strip_shortcodes( preg_replace(
+			array(
+				'|^(\s*)(https?://[^\s<>"]+)(\s*)$|im',
+				'/<script\b[^>]*>(.*?)<\/script>/is',
+			),
+			'',
+			$single_post->post_content
+		) ), $voicewp_instance::$ssml ) );
 		// Apply user defined dictionary to content as ssml
 		$dictionary = get_option( 'voicewp_user_dictionary', array() );
 		if ( ! empty( $dictionary ) ) {


### PR DESCRIPTION
Moves the preg_replace so that it only has to run once and will check for multiple items (standalone URL on a single line, and the new item, script tags)