### PR TITLE
Allow term slot to be filtered before query

### DIFF
--- a/alexa/skill/news.php
+++ b/alexa/skill/news.php
@@ -34,6 +34,7 @@ class News {
 			switch ( $intent ) {
 				case 'LatestTerm':
 					$term_slot = strtolower( sanitize_text_field( $request->getSlot( 'TermName' ) ) );
+					$term_slot = apply_filters( 'voicewp_filter_term_slot_result', $term_slot );
 					if ( $term_slot ) {
 						$news_taxonomies = voicewp_news_taxonomies();
 


### PR DESCRIPTION
if term values are a bit variable, allow them to be filtered. For example, ‘x ray’ and ‘x-ray’ may both be returned as a slot value. If only one is correct, this filter allows for checking and changing that value.